### PR TITLE
Fix integration tests logic

### DIFF
--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
@@ -6,43 +6,47 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - set_fact:
-        local_bucket_name: "{{ bucket_name | hash('md5')}}-bucket-key"
+    - name: Set facts for encryption_bucket_key test
+      set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5') }}-bucket-key"
     # ============================================================
 
-    - name: 'Create a simple bucket'
+    - name: "Create a simple bucket"
       s3_bucket:
-        name: '{{ local_bucket_name }}'
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - name: 'Enable aws:kms encryption with KMS master key'
+    - name: "Enable aws:kms encryption with KMS master key"
       s3_bucket:
-        name: '{{ local_bucket_name }}'
+        name: "{{ local_bucket_name }}"
         state: present
         encryption: "aws:kms"
       register: output
 
-    - name: 'Enable bucket key for bucket with aws:kms encryption'
+    - name: "Enable bucket key for bucket with aws:kms encryption"
       s3_bucket:
-        name: '{{ local_bucket_name }}'
+        name: "{{ local_bucket_name }}"
         state: present
         encryption: "aws:kms"
         bucket_key_enabled: true
       register: output
 
-    - assert:
+    - name: Assert for 'Enable bucket key for bucket with aws:kms encryption'
+      assert:
         that:
           - output.changed
           - output.encryption
 
-    - name: 'Re-enable bucket key for bucket with aws:kms encryption (idempotent)'
+    - name: "Re-enable bucket key for bucket with aws:kms encryption (idempotent)"
       s3_bucket:
-        name: '{{ local_bucket_name }}'
+        name: "{{ local_bucket_name }}"
+        encryption: "aws:kms"
         bucket_key_enabled: true
       register: output
 
-    - assert:
+    - name: Assert for 'Re-enable bucket key for bucket with aws:kms encryption (idempotent)''
+      assert:
         that:
           - not output.changed
           - output.encryption
@@ -51,22 +55,25 @@
 
     - name: Disable encryption from bucket
       s3_bucket:
-        name: '{{ local_bucket_name }}'
-        bucket_key_enabled: true
+        name: "{{ local_bucket_name }}"
+        encryption: none
+        bucket_key_enabled: false
       register: output
 
-    - assert:
+    - name: Assert for 'Disable encryption from bucket'
+      assert:
         that:
           - output.changed
           - not output.encryption
 
     - name: Disable encryption from bucket (idempotent)
       s3_bucket:
-        name: '{{ local_bucket_name }}'
+        name: "{{ local_bucket_name }}"
         bucket_key_enabled: true
       register: output
 
-    - assert:
+    - name: Assert for 'Disable encryption from bucket (idempotent)'
+      assert:
         that:
           - output is not changed
           - not output.encryption
@@ -75,11 +82,12 @@
 
     - name: Delete encryption test s3 bucket
       s3_bucket:
-        name: '{{ local_bucket_name }}'
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - name: Assert for 'Delete encryption test s3 bucket'
+      assert:
         that:
           - output.changed
 
@@ -87,6 +95,6 @@
   always:
     - name: Ensure all buckets are deleted
       s3_bucket:
-        name: '{{ local_bucket_name }}'
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      failed_when: false


### PR DESCRIPTION
@chirag1603 

Fixed 
- some Ansible code linting pieces
- every task has a name -> easier debugging
- test logic

It was failing on
```
TASK [s3_bucket : Assert for 'Disable encryption from bucket'] *****************************************************************************
fatal: [encryption_bucket_key]: FAILED! => {
    "assertion": "output.changed",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}
```

You originally had:
```
 name: Disable encryption from bucket (idempotent)
      s3_bucket:	
        name: '{{ local_bucket_name }}'
        bucket_key_enabled: true
```

But ^ it's not disabling encryption and therefore the following assert failed:

```"assertion": "output.changed"```